### PR TITLE
Update AppsFlyer SDK to 6.17.8 and bump min iOS to 12.0

### DIFF
--- a/AppsFlyerAdobeExtension.podspec
+++ b/AppsFlyerAdobeExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppsFlyerAdobeExtension'
-  s.version          = '6.17.7'
+  s.version          = '6.17.8'
   s.summary          = 'AppsFlyer iOS SDK Extension for Adobe Mobile SDK'
   s.description      = <<-DESC
 AppsFlyer iOS SDK Extension for Adobe Mobile SDK.
@@ -9,12 +9,12 @@ AppsFlyer iOS SDK Extension for Adobe Mobile SDK.
   s.license          = { :type => 'proprietary', :file => 'LICENSE' }
   s.author           = { 'AppsFlyer' => 'paz.lavi@appsflyer.com' }
   s.source           = { :git => 'https://github.com/AppsFlyerSDK/AppsFlyerAdobeExtension.git', :tag => s.version.to_s }
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '12.0'
   s.static_framework = true
   
   s.public_header_files = 'AppsFlyerAdobeExtension/Classes/**/*.h'
   s.source_files = 'AppsFlyerAdobeExtension/Classes/**/*'
   
-  s.dependency 'AppsFlyerFramework', '6.17.7'
+  s.dependency 'AppsFlyerFramework', '6.17.8'
   s.dependency 'ACPCore'
 end

--- a/AppsFlyerAdobeExtension/Classes/AppsFlyerAdobeExtension.m
+++ b/AppsFlyerAdobeExtension/Classes/AppsFlyerAdobeExtension.m
@@ -10,7 +10,7 @@
 #import "AppsFlyerAttribution.h"
 #import <objc/message.h>
 
-#define kAppsFlyerAdobeExtensionVersion @"6.17.7"
+#define kAppsFlyerAdobeExtensionVersion @"6.17.8"
 
 static AppsFlyerAdobeExtension *__sharedInstance = nil;
 static void (^__completionHandler)(NSDictionary*) = nil;

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -1,8 +1,8 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 use_frameworks!
 
 target 'AppsFlyerAdobeExtension_Example' do
-  pod 'AppsFlyerAdobeExtension', '6.17.7'
+  pod 'AppsFlyerAdobeExtension', '6.17.8'
   pod 'ACPAnalytics', '2.1.2'
   pod 'ACPCore', '~> 2.3.2'
   

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@
 
 ### <a id="plugin-build-for"> This plugin is built for
     
-- iOS AppsFlyer SDK **v6.17.7**
+- iOS AppsFlyer SDK **v6.17.8**
 
 ## <a id="add-sdk-to-project"> 📲 Adding the SDK to your project
 
 Add the following to your app's `Podfile`:
 
 ```javascript
-pod 'AppsFlyerAdobeExtension', '6.17.7'
+pod 'AppsFlyerAdobeExtension', '6.17.8'
 ```
 
 ## <a id="init-sdk"> 🚀 Initializing the SDK


### PR DESCRIPTION
## Changes

- Update AppsFlyer SDK from 6.17.7 to 6.17.8
- Bump minimum iOS deployment target from 11.0 to 12.0

## Testing

- Built and ran example app on iPhone 17
- Verified SDK starts correctly (v6.17.8)
- Verified conversion data callback received successfully